### PR TITLE
fix: change key of events to be unique instead of position in array

### DIFF
--- a/components/Events.tsx
+++ b/components/Events.tsx
@@ -48,7 +48,7 @@ const Events: FC<{
     <div>
       {latestEvents.map((ev, i) => {
         return (
-          <div key={i}>
+          <div key={ev.id}>
             <Event ev={ev} getRepoNameFromId={getRepoNameFromId} setEventAsOld={setEventAsOld} />
           </div>
         )

--- a/components/Repository.tsx
+++ b/components/Repository.tsx
@@ -97,7 +97,7 @@ const Repository: FC<{
           {' '}
           {eventData.map((event, i) => {
             return (
-              <div key={i}>
+              <div key={event.id}>
                 <Event ev={event} setEventAsOld={setEventAsOld} getRepoNameFromId={getRepoNameFromId} />
               </div>
             )


### PR DESCRIPTION
- Key used to be array position, led to behaviour where if 1st event (index 0) was open and a new event was added, the new event (index 0) would be open instead.
- Changing key to `event_id` makes it unique to the event and therefore fixes the issue